### PR TITLE
Remove insert mode escape mapping

### DIFF
--- a/nvim/.config/nvim/init.lua
+++ b/nvim/.config/nvim/init.lua
@@ -166,17 +166,10 @@ require('lazy').setup({
 })
 
 -----------------------------------------------------
--- Colorscheme
------------------------------------------------------
-
------------------------------------------------------
 -- Keymaps
 -----------------------------------------------------
 local map = vim.keymap.set
 local opts = { noremap = true, silent = true }
-
--- Insert mode escape
-map('i', 'jj', '<Esc>', opts)
 
 -- System clipboard helpers
 map('n', '<C-v>', '"+p', opts)

--- a/nvim/.config/nvim/init.vim
+++ b/nvim/.config/nvim/init.vim
@@ -104,8 +104,6 @@ colorscheme gruvbox
 "===============================
 " KEYBINDINGS
 "===============================
-" Insert mode escape
-inoremap jj <esc>
 
 " NERDTree toggle
 nnoremap <C-p> :NERDTree<CR>


### PR DESCRIPTION
Removed insert mode escape mapping for 'jj', because I should teach myself standard escaping for when it is not my config.